### PR TITLE
Fixed issue #1 set up Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Install the apt prerequisites
 before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y hugo
+    - wget https://github.com/gohugoio/hugo/releases/download/v0.36.1/hugo_0.36.1_Linux-64bit.deb
+    - sudo dpkg -i hugo*.deb
 
 # Build the website
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 # Install the apt prerequisites
-addons:
-  apt:
-    packages:
-      - python-pygments
-      - hugo
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y hugo
 
 # Build the website
 script:
-  - binaries/hugo --theme=fresh
+  - hugo
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ deploy:
   skip_cleanup: true
   github_token: $GITHUB_TOKEN
   local_dir: docs
+  target-branch: gh-pages
   on:
-    branch: gh-pages
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+# Install the apt prerequisites
+addons:
+  apt:
+    packages:
+      - python-pygments
+      - hugo
+
+# Build the website
+script:
+  - binaries/hugo --theme=fresh
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  local_dir: docs
+  on:
+    branch: gh-pages


### PR DESCRIPTION
I wrote a simple script for Travis CI, but there is still a lot to do on both GitHub and Travis.
1. Set up a GitHub personal access token, for a minimal requirement, `public_repo` should be checked.
2. Login to Travis, in the project settings, add an env environment named "GITHUB_TOKEN" (without quotes) with the value of access token above.
3. Switch back to GitHub, in the repo settings enable Github pages on **gh-pages branch** (by doing this we split the source code and compiled code on different branches).

On my forked [repo](https://github.com/HaoPatrick/intermine-homepage-2017), [link](https://haopatrick.github.io/intermine-homepage-2017/), a lot of CSS assets failed to load due to HTTPS issues, this should not happen on none-HTTPS sites (and can be totally fixed by upgrading CSS assets to HTTPS).
https://github.com/intermine/intermine-homepage-2017/issues/1