### PR TITLE
Fixes issue #8 Styled 'credits' item in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -26,8 +26,10 @@
             <a href="https://www.gen.cam.ac.uk/"><img src="{{.Site.BaseURL}}/images/cambridge-logo.png" alt="Part of the University of Cambridge" width="202" height="42" /></a>
             <a href="http://www.elixir-uk.org/"><img src="{{.Site.BaseURL}}/images/elixir-uk-logo.png" alt="InterMine is an ELIXIR-UK resource" width="80" height="80" /></a>
         </div>
-        </ul>
-        <div><a href="{{.Site.BaseURL}}/credits">Credits</a></div>
-        
+        <div><a href="{{.Site.BaseURL}}/credits">Credits
+                 <svg class="icon icon-linkout">
+                      <use xlink:href="{{.Site.BaseURL}}/images/symbol-defs.svg#icon-externallink"></use></svg></a>
+        </div>
+        <br/>
     </div>
 </footer>


### PR DESCRIPTION
The "Credits" item in footer is styled : 

Updated look :+1: 

![image](https://user-images.githubusercontent.com/14278142/37097043-7fbbe2fe-2240-11e8-8e45-675950d0eb3f.png)
