### PR TITLE
Fixed: Broken links in community calls section

### DIFF
--- a/content/community-calls/_index.md
+++ b/content/community-calls/_index.md
@@ -1,3 +1,3 @@
 {"title" : "Community calls"}
 
-We host two types of community calls, [Developer Calls](/community-calls/developers) and [Community Outreach Calls](/community-calls/outreach), aimed at slightly different but overlapping audiences. 
+We host two types of community calls, [Developer Calls](/community-calls/developer-calls) and [Community Outreach Calls](/community-calls/outreach-calls), aimed at slightly different but overlapping audiences. 

--- a/layouts/partials/linkscontact.html
+++ b/layouts/partials/linkscontact.html
@@ -49,7 +49,7 @@
       </svg>
     </a></li>
 
-  <li><a href="{{.Site.BaseURL}}community-calls">
+  <li><a href="{{.Site.BaseURL}}/community-calls">
     <svg class="icon icon-phone">
       <use xlink:href="{{.Site.BaseURL}}/images/symbol-defs.svg#icon-phone"></use>
     </svg>


### PR DESCRIPTION
@yochannah Hi, i hope you are well, so i was exploring the site and noticed that the contacts section in header has a broken link(in community calls)and both (community-calls/developer-calls) and (outreach-calls) links, so i fixed them, i hope you like the changes, i would like some feedback to know if i am taking the right way, i am very glad to contribute to this project! have a great week, thanks for any suggestion.