### PR TITLE
embedded python tutorials in training section.

### DIFF
--- a/content/tutorials/index.md
+++ b/content/tutorials/index.md
@@ -3,7 +3,7 @@
 
 ## Training workshops and Exercises
 
-We typically carry out a few training workshops each year - keep your eye on our [calendar](https://intermineorg.wordpress.com/events/) or [twitter feed]https://twitter.com/intermineorg) to find out when registration is open. The [materials are available online](http://intermine.org/training-workshops/) and designed to be worked through in a self-led or tutor-led manner. These include:  
+We typically carry out a few training workshops each year - keep your eye on our [calendar](https://intermineorg.wordpress.com/events/) or [twitter feed](https://twitter.com/intermineorg/) to find out when registration is open. The [materials are available online](http://intermine.org/training-workshops/) and designed to be worked through in a self-led or tutor-led manner. These include:  
 
 - [Intro to data analysis with the InterMine user interface](http://intermine.org/training-workshops//2019/2019-06-19-genetics-ui)
 - 🐍 Data analysis workflows in Python

--- a/content/tutorials/index.md
+++ b/content/tutorials/index.md
@@ -28,3 +28,4 @@ Here's a short list of video tutorials produced by community members. If you'd l
 - [TargetMine tutorials](http://targetmine.mizuguchilab.org/tutorials) Tutorials for an InterMine designed to help identify drug targets.
 - [YeastMine videos](https://www.youtube.com/watch?v=fnWv6qRl_DA&list=PL0VHJdmmIuj-b00aNRfqwMe9TvkfWWcyZ) - SGD has quite a broad range of tutorials based on S. Cerevisiae data.
 - [MouseMine at MGI](https://www.youtube.com/watch?v=FtlsoM8TGGs&t=139s) - M. musculus InterMine intro
+- [Python tutorials](https://hub.gke.mybinder.org/user/intermine-inter--ws-python-docs-dj5qvykk/tree) - Tutorials to help you get familiarised with the intermine-python package. The tutorials are in the form of Jupyter-Notebooks.

--- a/content/tutorials/index.md
+++ b/content/tutorials/index.md
@@ -25,7 +25,7 @@ Here's a short list of video tutorials produced by community members. If you'd l
 
 - [FlyMine intro videos](http://intermine.readthedocs.io/en/latest/help/) - for the Drosophila-minded among us.
 - [Thalemine tutorials](https://www.araport.org/tutorials) - A. thaliana-based tutorials.
-- [TargetMine tutorials](http://targetmine.mizuguchilab.org/tutorials) Tutorials for an InterMine designed to help identify drug targets.
+- [TargetMine tutorials](http://targetmine.mizuguchilab.org/tutorials) -Tutorials for an InterMine designed to help identify drug targets.
 - [YeastMine videos](https://www.youtube.com/watch?v=fnWv6qRl_DA&list=PL0VHJdmmIuj-b00aNRfqwMe9TvkfWWcyZ) - SGD has quite a broad range of tutorials based on S. Cerevisiae data.
 - [MouseMine at MGI](https://www.youtube.com/watch?v=FtlsoM8TGGs&t=139s) - M. musculus InterMine intro
 - [Python tutorials](https://hub.gke.mybinder.org/user/intermine-inter--ws-python-docs-dj5qvykk/tree) - Tutorials to help you get familiarised with the intermine-python package. The tutorials are in the form of Jupyter-Notebooks.


### PR DESCRIPTION
Hi @yochannah Please review the changes. 
Also the link to "Thalemine tutorials" is broken. It says-
![image](https://user-images.githubusercontent.com/53967592/77730854-aacfc500-7027-11ea-80e5-a95781a05c2a.png)
I searched a lot and I guess correct link would be-https://bar.utoronto.ca/thalemine/begin.do
If this is the correct link I can add this link. Thank you!
