### PR TITLE
Fixing community-calls broken links in Contacts Section

### DIFF
--- a/content/community-calls/_index.md
+++ b/content/community-calls/_index.md
@@ -1,3 +1,3 @@
 {"title" : "Community calls"}
 
-We host two types of community calls, [Developer Calls](/community-calls/developers) and [Community Outreach Calls](/community-calls/outreach), aimed at slightly different but overlapping audiences. 
+We host two types of community calls, [Developer Calls](/community-calls/developer-calls) and [Community Outreach Calls](/community-calls/outreach-calls), aimed at slightly different but overlapping audiences. 

--- a/docs/community-calls/index.html
+++ b/docs/community-calls/index.html
@@ -129,7 +129,7 @@
       </svg>
     </a></li>
 
-  <li><a href="http://intermine.orgcommunity-calls">
+  <li><a href="http://intermine.org/community-calls">
     <svg class="icon icon-phone">
       <use xlink:href="http://intermine.org/images/symbol-defs.svg#icon-phone"></use>
     </svg>
@@ -175,7 +175,7 @@
           Community calls
         </h2>
         <div class="header community-calls">
-        <p>We host two types of community calls, <a href="/community-calls/developers">Developer Calls</a> and <a href="/community-calls/outreach">Community Outreach Calls</a>, aimed at slightly different but overlapping audiences.</p>
+        <p>We host two types of community calls, <a href="/community-calls/developer-calls">Developer Calls</a> and <a href="/community-calls/outreach-calls">Community Outreach Calls</a>, aimed at slightly different but overlapping audiences.</p>
 
         </div>
     <div class="main-articles">
@@ -344,7 +344,7 @@
       </svg>
     </a></li>
 
-  <li><a href="http://intermine.orgcommunity-calls">
+  <li><a href="http://intermine.org/community-calls">
     <svg class="icon icon-phone">
       <use xlink:href="http://intermine.org/images/symbol-defs.svg#icon-phone"></use>
     </svg>

--- a/docs/community-calls/outreach-calls/index.html
+++ b/docs/community-calls/outreach-calls/index.html
@@ -129,7 +129,7 @@
       </svg>
     </a></li>
 
-  <li><a href="http://intermine.orgcommunity-calls">
+  <li><a href="http://intermine.org/community-calls">
     <svg class="icon icon-phone">
       <use xlink:href="http://intermine.org/images/symbol-defs.svg#icon-phone"></use>
     </svg>
@@ -307,7 +307,7 @@
       </svg>
     </a></li>
 
-  <li><a href="http://intermine.orgcommunity-calls">
+  <li><a href="http://intermine.org/community-calls">
     <svg class="icon icon-phone">
       <use xlink:href="http://intermine.org/images/symbol-defs.svg#icon-phone"></use>
     </svg>

--- a/docs/contact/index.html
+++ b/docs/contact/index.html
@@ -129,7 +129,7 @@
       </svg>
     </a></li>
 
-  <li><a href="http://intermine.orgcommunity-calls">
+  <li><a href="http://intermine.org/community-calls">
     <svg class="icon icon-phone">
       <use xlink:href="http://intermine.org/images/symbol-defs.svg#icon-phone"></use>
     </svg>
@@ -239,7 +239,7 @@
       </svg>
     </a></li>
 
-  <li><a href="http://intermine.orgcommunity-calls">
+  <li><a href="http://intermine.org/community-calls">
     <svg class="icon icon-phone">
       <use xlink:href="http://intermine.org/images/symbol-defs.svg#icon-phone"></use>
     </svg>

--- a/layouts/partials/linkscontact.html
+++ b/layouts/partials/linkscontact.html
@@ -49,7 +49,7 @@
       </svg>
     </a></li>
 
-  <li><a href="{{.Site.BaseURL}}community-calls">
+  <li><a href="{{.Site.BaseURL}}/community-calls">
     <svg class="icon icon-phone">
       <use xlink:href="{{.Site.BaseURL}}/images/symbol-defs.svg#icon-phone"></use>
     </svg>


### PR DESCRIPTION
Fixed: community-calls broken links in Contacts Section in the header /footer of the website, and developer-calls and outreach-calls broken links in community-calls page.