### PR TITLE
Add Intermine Intership link in contact page to students interested 

### DIFF
--- a/content/contact/_index.md
+++ b/content/contact/_index.md
@@ -4,7 +4,7 @@ The InterMine core team is based in Cambridge, UK, roughly 8am until 5pm most we
 
 ## Students
 
-If you're interested in working with us as a student, please visit our [Google Summer of Code site](http://intermine.org/gsoc/).
+If you're interested in working with us as a student, please visit our [InterMine Internships page](http://intermine.org/internships/).
 
 ## Community calls
 

--- a/content/tutorials/index.md
+++ b/content/tutorials/index.md
@@ -21,7 +21,7 @@ We typically carry out a few training workshops each year - keep your eye on our
 
 ## Videos
 
-Here's a short list of video tutorials produced by community members. If you'd like yours added to the list please contact us!
+Here's a short list of video tutorials produced by community members. If you'd like yours added to the list please [contact us](http://intermine.org/contact/)!
 
 - [FlyMine intro videos](http://intermine.readthedocs.io/en/latest/help/) - for the Drosophila-minded among us.
 - [Thalemine tutorials](https://www.araport.org/tutorials) - A. thaliana-based tutorials.


### PR DESCRIPTION
@yochannah i hope you are fine! i was exploring the Contact page on Intermine Website and noticed there's a link to Intermine GSoC page to students interested in work with Intermine, but this was page was moved to Intermine Intership Page, so i changed the link(before GSoG Intermine page, which is now moved) to Intermine Intership page so  the users can go directly to the respective page, i hope you like the change.