### PR TITLE
Query param for publications page to highlight link at top

### DIFF
--- a/layouts/section/publications.html
+++ b/layouts/section/publications.html
@@ -59,6 +59,29 @@
 
   {{partial "footer.html" . }}
 
+  <script>
+    // Check for the doi query parameter, and if present, copy the publication
+    // using the same doi URL into a highlighted element near the top.
+    (function () {
+      try {
+        if (!window.location.search.length) return;
+        var urlParams = new URLSearchParams(window.location.search);
+        var doiParam = urlParams.get("doi");
+        if (!doiParam.length) return;
+        var doiUrl = "http://doi.org/" + doiParam;
+        var anchorElem = document.querySelector("a[href='" + doiUrl + "']");
+        var citeElem = anchorElem.parentNode.cloneNode(true);
+        citeElem.classList.add("highlight-publication");
+        var paragraphElem = document.createElement("p");
+        paragraphElem.appendChild(document.createTextNode("We recommend you cite the following publication: "));
+        var headingElem = document.querySelector("body main h2");
+        headingElem.after(citeElem);
+        headingElem.after(paragraphElem);
+      } catch (error) {
+        console.error("Error occured when trying to acquire publication linked with doi parameter", error);
+      }
+    })();
+  </script>
 </body>
 
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -147,7 +147,7 @@ body {
   background-color: rgba(0, 0, 0, 0.04);
 }
 a {
-  color: #0329F4;
+  color: #03A9F4;
   transition-property: all;
   transition-delay: 0.5s;
   transition-duration: 0.6s;
@@ -161,7 +161,7 @@ a:hover {
   transition-delay: 0s;
 }
 a:visited {
-  color: #512e90;
+  color: #673AB7;
   transition-property: all;
   transition-delay: 0.5s;
   transition-duration: 0.6s;
@@ -1249,6 +1249,10 @@ footer .funders img {
   width: 2em;
   height: 2em;
 }
+.highlight-publication {
+  background-color: #fbe90f;
+  padding: 0.5em 1em;
+}
 .contactpage li {
   list-style-type: none;
   background-color: #e5e5e5;
@@ -1312,7 +1316,3 @@ footer .funders img {
 p:empty {
   display: none;
 }
-
-header.menu-open { 
-  transition:none; 
-} 

--- a/static/style.less
+++ b/static/style.less
@@ -1206,6 +1206,11 @@ footer {
   }
 }
 
+.highlight-publication {
+  background-color: #fbe90f;
+  padding: @spacer/2 @spacer;
+}
+
 .contactpage {
   li {
     list-style-type: none;


### PR DESCRIPTION
The doi query parameter in the URL should match a doi.org path present among the publications listed below. If the parameter is present and there's a match, the publication will be copied to the top of the page and the user recommended to cite it.

This is meant to be used from Bluegenes for Flymine and Humanmine, instead of linking directly to the publication.